### PR TITLE
docs: Add missing provider documentation source file

### DIFF
--- a/internal/provider/provider.md
+++ b/internal/provider/provider.md
@@ -1,0 +1,9 @@
+The Defined.net (`definednet`) provider is used to interact with their managed Nebula overlay network control plane.
+
+Use the navigation to the left to read about the available resources.
+
+## Provider Configuration
+
+The provider needs to be configured with the proper credentials before it can be used.
+
+Refer to each resource's documentation for the required token scope.


### PR DESCRIPTION
The source file was accidentally left unstaged.