### PR TITLE
tooling: Run CI test pipeline only for pushes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,9 +4,6 @@ name: Tests
 # This GitHub action runs your tests for each pull request and push.
 # Optionally, you can turn it on using a schedule for regular testing.
 on:
-  pull_request:
-    paths-ignore:
-      - "README.md"
   push:
     paths-ignore:
       - "README.md"


### PR DESCRIPTION
Prevent duplicate executions for opened pull requests and code pushes.