### PR TITLE
provider: Introduce generic `definednet.Response` type

### DIFF
--- a/internal/definednet/client.go
+++ b/internal/definednet/client.go
@@ -40,6 +40,11 @@ type Client interface {
 	Do(ctx context.Context, method string, path []string, request, response any) error
 }
 
+// Response is a generic data model for Defined.net responses.
+type Response[D any] struct {
+	Data D `json:"data"`
+}
+
 type client struct {
 	endpoint *url.URL
 	token    string

--- a/internal/definednet/client_test.go
+++ b/internal/definednet/client_test.go
@@ -6,7 +6,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/ghttp"
-	"github.com/onsi/gomega/gstruct"
+	. "github.com/onsi/gomega/gstruct"
 	"github.com/sendsmaily/terraform-provider-definednet/internal/definednet"
 )
 
@@ -45,7 +45,7 @@ var _ = Describe("executing API requests", func() {
 
 			Expect(server.ReceivedRequests()).
 				To(HaveExactElements(
-					HaveField("Header", gstruct.MatchKeys(gstruct.IgnoreExtras, gstruct.Keys{
+					HaveField("Header", MatchKeys(IgnoreExtras, Keys{
 						"Accept":        HaveExactElements("application/json"),
 						"Authorization": HaveExactElements("Bearer supersecret"),
 						"User-Agent":    HaveExactElements("Terraform-smaily-definednet/0.1.0"),
@@ -147,9 +147,9 @@ var _ = Describe("handling HTTP API success responses", func() {
 		}))
 
 		Expect(client.Do(ctx, http.MethodGet, []string{}, nil, &container)).To(Succeed())
-		Expect(container).To(gstruct.MatchAllFields(gstruct.Fields{
+		Expect(container).To(MatchAllFields(Fields{
 			"Field": Equal("value"),
-			"Nested": gstruct.MatchAllFields(gstruct.Fields{
+			"Nested": MatchAllFields(Fields{
 				"Field": Equal("nested_value"),
 			}),
 		}))
@@ -167,9 +167,9 @@ var _ = Describe("handling HTTP API success responses", func() {
 		}))
 
 		Expect(client.Do(ctx, http.MethodGet, []string{}, nil, &container)).To(Succeed())
-		Expect(container).To(gstruct.MatchAllFields(gstruct.Fields{
+		Expect(container).To(MatchAllFields(Fields{
 			"Field": Equal("value"),
-			"Nested": gstruct.MatchAllFields(gstruct.Fields{
+			"Nested": MatchAllFields(Fields{
 				"Field": Equal("nested_value"),
 			}),
 		}), "assert sanity")

--- a/internal/definednet/enrollmentcode.go
+++ b/internal/definednet/enrollmentcode.go
@@ -7,12 +7,12 @@ import (
 
 // CreateEnrollmentCode creates a Defined.net host enrollment code.
 func CreateEnrollmentCode(ctx context.Context, client Client, req CreateEnrollmentCodeRequest) (*CreateEnrollmentCodeResponse, error) {
-	var resp CreateEnrollmentCodeResponse
+	var resp Response[CreateEnrollmentCodeResponse]
 	if err := client.Do(ctx, http.MethodPost, []string{"v1", "hosts", req.ID, "enrollment-code"}, nil, &resp); err != nil {
 		return nil, err
 	}
 
-	return &resp, nil
+	return &resp.Data, nil
 }
 
 type (
@@ -23,9 +23,7 @@ type (
 
 	// CreateEnrollmentCodeResponse is a response data model for CreateEnrollmentCode endpoint.
 	CreateEnrollmentCodeResponse struct {
-		Data struct {
-			Code            string `json:"code"`
-			LifetimeSeconds int    `json:"lifetimeSeconds"`
-		} `json:"data"`
+		Code            string `json:"code"`
+		LifetimeSeconds int    `json:"lifetimeSeconds"`
 	}
 )

--- a/internal/definednet/enrollmentcode_test.go
+++ b/internal/definednet/enrollmentcode_test.go
@@ -27,10 +27,8 @@ var _ = Describe("creating enrollment codes", func() {
 		server.AppendHandlers(ghttp.RespondWith(http.StatusOK, enrollmentCodeJSONResponse))
 		Expect(definednet.CreateEnrollmentCode(ctx, client, definednet.CreateEnrollmentCodeRequest{})).
 			To(PointTo(MatchAllFields(Fields{
-				"Data": MatchAllFields(Fields{
-					"Code":            Equal("supersecret"),
-					"LifetimeSeconds": Equal(300),
-				}),
+				"Code":            Equal("supersecret"),
+				"LifetimeSeconds": Equal(300),
 			})))
 		Expect(server.ReceivedRequests()).NotTo(BeEmpty(), "assert sanity")
 	})

--- a/internal/definednet/host.go
+++ b/internal/definednet/host.go
@@ -7,12 +7,12 @@ import (
 
 // CreateHost creates a Defined.net host.
 func CreateHost(ctx context.Context, client Client, req CreateHostRequest) (*CreateHostResponse, error) {
-	var resp CreateHostResponse
+	var resp Response[CreateHostResponse]
 	if err := client.Do(ctx, http.MethodPost, []string{"v1", "hosts"}, req, &resp); err != nil {
 		return nil, err
 	}
 
-	return &resp, nil
+	return &resp.Data, nil
 }
 
 type (
@@ -31,18 +31,16 @@ type (
 
 	// CreateHostResponse is a response data model for CreateHost endpoint.
 	CreateHostResponse struct {
-		Data struct {
-			ID              string   `json:"id"`
-			NetworkID       string   `json:"networkID"`
-			RoleID          string   `json:"roleID"`
-			Name            string   `json:"name"`
-			IPAddress       string   `json:"ipAddress"`
-			StaticAddresses []string `json:"staticAddresses"`
-			ListenPort      int      `json:"listenPort"`
-			IsLighthouse    bool     `json:"isLighthouse"`
-			IsRelay         bool     `json:"isRelay"`
-			Tags            []string `json:"tags"`
-		} `json:"data"`
+		ID              string   `json:"id"`
+		NetworkID       string   `json:"networkID"`
+		RoleID          string   `json:"roleID"`
+		Name            string   `json:"name"`
+		IPAddress       string   `json:"ipAddress"`
+		StaticAddresses []string `json:"staticAddresses"`
+		ListenPort      int      `json:"listenPort"`
+		IsLighthouse    bool     `json:"isLighthouse"`
+		IsRelay         bool     `json:"isRelay"`
+		Tags            []string `json:"tags"`
 	}
 )
 
@@ -60,12 +58,12 @@ type (
 
 // GetHost retrieves a Defined.net host.
 func GetHost(ctx context.Context, client Client, req GetHostRequest) (*GetHostResponse, error) {
-	var resp GetHostResponse
+	var resp Response[GetHostResponse]
 	if err := client.Do(ctx, http.MethodGet, []string{"v1", "hosts", req.ID}, nil, &resp); err != nil {
 		return nil, err
 	}
 
-	return &resp, nil
+	return &resp.Data, nil
 }
 
 type (
@@ -76,29 +74,27 @@ type (
 
 	// GetHostResponse is a response data model for GetHost endpoint.
 	GetHostResponse struct {
-		Data struct {
-			ID              string   `json:"id"`
-			NetworkID       string   `json:"networkID"`
-			RoleID          string   `json:"roleID"`
-			Name            string   `json:"name"`
-			IPAddress       string   `json:"ipAddress"`
-			StaticAddresses []string `json:"staticAddresses"`
-			ListenPort      int      `json:"listenPort"`
-			IsLighthouse    bool     `json:"isLighthouse"`
-			IsRelay         bool     `json:"isRelay"`
-			Tags            []string `json:"tags"`
-		} `json:"data"`
+		ID              string   `json:"id"`
+		NetworkID       string   `json:"networkID"`
+		RoleID          string   `json:"roleID"`
+		Name            string   `json:"name"`
+		IPAddress       string   `json:"ipAddress"`
+		StaticAddresses []string `json:"staticAddresses"`
+		ListenPort      int      `json:"listenPort"`
+		IsLighthouse    bool     `json:"isLighthouse"`
+		IsRelay         bool     `json:"isRelay"`
+		Tags            []string `json:"tags"`
 	}
 )
 
 // UpdateHost updates a Defined.net host.
 func UpdateHost(ctx context.Context, client Client, req UpdateHostRequest) (*UpdateHostResponse, error) {
-	var resp UpdateHostResponse
+	var resp Response[UpdateHostResponse]
 	if err := client.Do(ctx, http.MethodPut, []string{"v1", "hosts", req.ID}, req, &resp); err != nil {
 		return nil, err
 	}
 
-	return &resp, nil
+	return &resp.Data, nil
 }
 
 type (
@@ -114,17 +110,15 @@ type (
 
 	// UpdateHostResponse is a response data model for UpdateHost endpoint.
 	UpdateHostResponse struct {
-		Data struct {
-			ID              string   `json:"id"`
-			NetworkID       string   `json:"networkID"`
-			RoleID          string   `json:"roleID"`
-			Name            string   `json:"name"`
-			IPAddress       string   `json:"ipAddress"`
-			StaticAddresses []string `json:"staticAddresses"`
-			ListenPort      int      `json:"listenPort"`
-			IsLighthouse    bool     `json:"isLighthouse"`
-			IsRelay         bool     `json:"isRelay"`
-			Tags            []string `json:"tags"`
-		} `json:"data"`
+		ID              string   `json:"id"`
+		NetworkID       string   `json:"networkID"`
+		RoleID          string   `json:"roleID"`
+		Name            string   `json:"name"`
+		IPAddress       string   `json:"ipAddress"`
+		StaticAddresses []string `json:"staticAddresses"`
+		ListenPort      int      `json:"listenPort"`
+		IsLighthouse    bool     `json:"isLighthouse"`
+		IsRelay         bool     `json:"isRelay"`
+		Tags            []string `json:"tags"`
 	}
 )

--- a/internal/definednet/host_test.go
+++ b/internal/definednet/host_test.go
@@ -46,18 +46,16 @@ var _ = Describe("creating hosts", func() {
 		server.AppendHandlers(ghttp.RespondWith(http.StatusOK, hostJSONResponse))
 		Expect(definednet.CreateHost(ctx, client, definednet.CreateHostRequest{})).
 			To(PointTo(MatchAllFields(Fields{
-				"Data": MatchAllFields(Fields{
-					"ID":              Equal("host-id"),
-					"NetworkID":       Equal("network-id"),
-					"RoleID":          Equal("role-id"),
-					"Name":            Equal("host.smaily.testing"),
-					"IPAddress":       Equal("10.0.0.1"),
-					"StaticAddresses": HaveExactElements("127.0.0.1:8484", "172.16.0.1:8484"),
-					"ListenPort":      Equal(8484),
-					"IsLighthouse":    BeTrue(),
-					"IsRelay":         BeTrue(),
-					"Tags":            HaveExactElements("tag:one", "tag:two"),
-				}),
+				"ID":              Equal("host-id"),
+				"NetworkID":       Equal("network-id"),
+				"RoleID":          Equal("role-id"),
+				"Name":            Equal("host.smaily.testing"),
+				"IPAddress":       Equal("10.0.0.1"),
+				"StaticAddresses": HaveExactElements("127.0.0.1:8484", "172.16.0.1:8484"),
+				"ListenPort":      Equal(8484),
+				"IsLighthouse":    BeTrue(),
+				"IsRelay":         BeTrue(),
+				"Tags":            HaveExactElements("tag:one", "tag:two"),
 			})))
 		Expect(server.ReceivedRequests()).NotTo(BeEmpty(), "assert sanity")
 	})
@@ -83,18 +81,16 @@ var _ = Describe("getting hosts", func() {
 		Expect(definednet.GetHost(ctx, client, definednet.GetHostRequest{
 			ID: "host-id",
 		})).To(PointTo(MatchAllFields(Fields{
-			"Data": MatchAllFields(Fields{
-				"ID":              Equal("host-id"),
-				"NetworkID":       Equal("network-id"),
-				"RoleID":          Equal("role-id"),
-				"Name":            Equal("host.smaily.testing"),
-				"IPAddress":       Equal("10.0.0.1"),
-				"StaticAddresses": HaveExactElements("127.0.0.1:8484", "172.16.0.1:8484"),
-				"ListenPort":      Equal(8484),
-				"IsLighthouse":    BeTrue(),
-				"IsRelay":         BeTrue(),
-				"Tags":            HaveExactElements("tag:one", "tag:two"),
-			}),
+			"ID":              Equal("host-id"),
+			"NetworkID":       Equal("network-id"),
+			"RoleID":          Equal("role-id"),
+			"Name":            Equal("host.smaily.testing"),
+			"IPAddress":       Equal("10.0.0.1"),
+			"StaticAddresses": HaveExactElements("127.0.0.1:8484", "172.16.0.1:8484"),
+			"ListenPort":      Equal(8484),
+			"IsLighthouse":    BeTrue(),
+			"IsRelay":         BeTrue(),
+			"Tags":            HaveExactElements("tag:one", "tag:two"),
 		})))
 		Expect(server.ReceivedRequests()).NotTo(BeEmpty(), "assert sanity")
 	})
@@ -129,18 +125,16 @@ var _ = Describe("updating hosts", func() {
 		server.AppendHandlers(ghttp.RespondWith(http.StatusOK, hostJSONResponse))
 		Expect(definednet.UpdateHost(ctx, client, definednet.UpdateHostRequest{})).
 			To(PointTo(MatchAllFields(Fields{
-				"Data": MatchAllFields(Fields{
-					"ID":              Equal("host-id"),
-					"NetworkID":       Equal("network-id"),
-					"RoleID":          Equal("role-id"),
-					"Name":            Equal("host.smaily.testing"),
-					"IPAddress":       Equal("10.0.0.1"),
-					"StaticAddresses": HaveExactElements("127.0.0.1:8484", "172.16.0.1:8484"),
-					"ListenPort":      Equal(8484),
-					"IsLighthouse":    BeTrue(),
-					"IsRelay":         BeTrue(),
-					"Tags":            HaveExactElements("tag:one", "tag:two"),
-				}),
+				"ID":              Equal("host-id"),
+				"NetworkID":       Equal("network-id"),
+				"RoleID":          Equal("role-id"),
+				"Name":            Equal("host.smaily.testing"),
+				"IPAddress":       Equal("10.0.0.1"),
+				"StaticAddresses": HaveExactElements("127.0.0.1:8484", "172.16.0.1:8484"),
+				"ListenPort":      Equal(8484),
+				"IsLighthouse":    BeTrue(),
+				"IsRelay":         BeTrue(),
+				"Tags":            HaveExactElements("tag:one", "tag:two"),
 			})))
 		Expect(server.ReceivedRequests()).NotTo(BeEmpty(), "assert sanity")
 	})


### PR DESCRIPTION
Provide a data model with common fields to simplify working with Defined.net HTTP API responses.