### PR TITLE
provider: Fix Defined.net HTTP API client's host update endpoint

### DIFF
--- a/internal/definednet/host.go
+++ b/internal/definednet/host.go
@@ -70,7 +70,7 @@ type GetHostRequest struct {
 // UpdateHost updates a Defined.net host.
 func UpdateHost(ctx context.Context, client Client, req UpdateHostRequest) (*Host, error) {
 	var resp Response[Host]
-	if err := client.Do(ctx, http.MethodPut, []string{"v1", "hosts", req.ID}, req, &resp); err != nil {
+	if err := client.Do(ctx, http.MethodPut, []string{"v2", "hosts", req.ID}, req, &resp); err != nil {
 		return nil, err
 	}
 

--- a/internal/definednet/host_test.go
+++ b/internal/definednet/host_test.go
@@ -99,7 +99,7 @@ var _ = Describe("getting hosts", func() {
 var _ = Describe("updating hosts", func() {
 	Specify("hosts are updated on Defined.net", func(ctx SpecContext) {
 		server.AppendHandlers(ghttp.CombineHandlers(
-			ghttp.VerifyRequest(http.MethodPut, "/v1/hosts/host-id"),
+			ghttp.VerifyRequest(http.MethodPut, "/v2/hosts/host-id"),
 			ghttp.VerifyJSONRepresenting(map[string]any{
 				"roleID":          "role-id",
 				"name":            "host.smaily.testing",


### PR DESCRIPTION
The HTTP API provides `PUT /v2/hosts/:id` endpoint instead of the currently configured `PUT /v1/hosts/:id`.