### PR TITLE
validation: Simplify IP address validator's public API signature

### DIFF
--- a/internal/validation/ipaddress.go
+++ b/internal/validation/ipaddress.go
@@ -11,13 +11,11 @@ import (
 // IPAddress validates the value is an IP address.
 //
 // Null (unconfigured) and unknown (known after apply) values are skipped.
-func IPAddress() ipaddressValidator {
+func IPAddress() validator.String {
 	return ipaddressValidator{}
 }
 
 type ipaddressValidator struct{}
-
-var _ validator.String = ipaddressValidator{}
 
 func (validator ipaddressValidator) Description(_ context.Context) string {
 	return "value must be an IP address"


### PR DESCRIPTION
Return `validator.String` sealed interface for `IPAddress()` validator to reduce the public API surface area.