### PR TITLE
resource: Implement schema validation rules

### DIFF
--- a/internal/resource/host/schema.go
+++ b/internal/resource/host/schema.go
@@ -3,26 +3,26 @@ package host
 import (
 	_ "embed"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/sendsmaily/terraform-provider-definednet/internal/validation"
 )
 
 // Schema is the host resource's schema.
 var Schema = schema.Schema{
 	MarkdownDescription: resourceDescription,
 	Attributes: map[string]schema.Attribute{
-		"id": schema.StringAttribute{
-			Description: "Host's ID",
-			Computed:    true,
-			PlanModifiers: []planmodifier.String{
-				stringplanmodifier.UseStateForUnknown(),
-			},
-		},
 		"name": schema.StringAttribute{
 			Description: "Host's name",
 			Required:    true,
+			Validators: []validator.String{
+				stringvalidator.LengthAtMost(255),
+			},
 		},
 		"network_id": schema.StringAttribute{
 			Description: "Enrolled Network ID",
@@ -35,17 +35,28 @@ var Schema = schema.Schema{
 			Description: "Host's role ID on Defined.net",
 			Optional:    true,
 		},
+		"tags": schema.ListAttribute{
+			Description: "Host's tags on Defined.net",
+			ElementType: types.StringType,
+			Optional:    true,
+			Validators: []validator.List{
+				listvalidator.UniqueValues(),
+				listvalidator.ValueStringsAre(validation.HostTag()),
+			},
+		},
+		"id": schema.StringAttribute{
+			Description: "Host's ID",
+			Computed:    true,
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.UseStateForUnknown(),
+			},
+		},
 		"ip_address": schema.StringAttribute{
 			Description: "Host's IP address on Defined.net overlay network",
 			Computed:    true,
 			PlanModifiers: []planmodifier.String{
 				stringplanmodifier.UseStateForUnknown(),
 			},
-		},
-		"tags": schema.ListAttribute{
-			Description: "Host's tags on Defined.net",
-			ElementType: types.StringType,
-			Optional:    true,
 		},
 		"enrollment_code": schema.StringAttribute{
 			Description: "Host's enrollment code",

--- a/internal/resource/lighthouse/schema.go
+++ b/internal/resource/lighthouse/schema.go
@@ -3,10 +3,14 @@ package lighthouse
 import (
 	_ "embed"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/sendsmaily/terraform-provider-definednet/internal/validation"
 )
 
 // Schema is the lighthouse resource's schema.
@@ -16,6 +20,9 @@ var Schema = schema.Schema{
 		"name": schema.StringAttribute{
 			Description: "Lighthouse's name",
 			Required:    true,
+			Validators: []validator.String{
+				stringvalidator.LengthAtMost(255),
+			},
 		},
 		"network_id": schema.StringAttribute{
 			Description: "Enrolled Network ID",
@@ -32,6 +39,10 @@ var Schema = schema.Schema{
 			Description: "Lighthouse's static IP addresses",
 			ElementType: types.StringType,
 			Required:    true,
+			Validators: []validator.List{
+				listvalidator.UniqueValues(),
+				listvalidator.ValueStringsAre(validation.IPAddress()),
+			},
 		},
 		"listen_port": schema.Int32Attribute{
 			Description: "Lighthouse's listen port",
@@ -41,6 +52,10 @@ var Schema = schema.Schema{
 			Description: "Lighthouse's tags on Defined.net",
 			ElementType: types.StringType,
 			Optional:    true,
+			Validators: []validator.List{
+				listvalidator.UniqueValues(),
+				listvalidator.ValueStringsAre(validation.HostTag()),
+			},
 		},
 		"id": schema.StringAttribute{
 			Description: "Lighthouse's ID",


### PR DESCRIPTION
* Validate `name` attribute on `host.Schema` and `lighthouse.Schema` conforms to a maximum length constraint.
* Validate `tags` attribute on `host.Schema` and `lighthouse.Schema` conforms to the expected format constraint.
* Validate `static_addresses` attribute contains a list of IP addresses on `lighthouse.Schema`.