### PR TITLE
docs: Remove warning on creating real resources from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,4 @@ To generate or update documentation, run `make generate`.
 
 In order to run the full suite of Acceptance tests, run `make testacc`.
 
-*Note:* Acceptance tests create real resources, and often cost money to run.
-
-```shell
-make testacc
-```
-
 > Consult the official documentation for more information on the test framework's internals: https://developer.hashicorp.com/terraform/plugin/testing.


### PR DESCRIPTION
The provider implements a fake Defined.net HTTP API server for running acceptance tests making the warning irrelevant.