### PR TITLE
tooling: Reconfigure Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,12 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    groups:
+      update:
+        applies-to: version-updates
+    prefix: "deps"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
+    prefix: "tooling"


### PR DESCRIPTION
* Group Golang dependency version updates to reduce Dependabot's PR noise.
* Adjust Dependabot's PR titles to use `deps` prefix for dependency version updates.
* Adjust Dependabot's PR titles to use `tooling` prefix for Github Action version updates.