### PR TITLE
tooling: Fix Dependabot's configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,7 @@ updates:
       interval: "daily"
     groups:
       update:
+        dependency-type: production
         applies-to: version-updates
     prefix: "deps"
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
Add missing `dependency-type` key to `update` group.