### PR TITLE
tooling: Fix Dependabot's commit message prefixing configuration [skip ci]

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,9 +10,11 @@ updates:
       update:
         dependency-type: production
         applies-to: version-updates
-    prefix: "deps"
+    commit-message:
+      prefix: "deps"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
-    prefix: "tooling"
+    commit-message:
+      prefix: "tooling"


### PR DESCRIPTION
The stated prefix needs to be configured under `commit-message` key.