### PR TITLE
internal/resource: Fix optional field handling in `definednet_lighthouse` and `definednet_host` resources

### DIFF
--- a/internal/resource/host/resource_test.go
+++ b/internal/resource/host/resource_test.go
@@ -172,4 +172,15 @@ var _ = DescribeTable("host resource management",
 			ImportStateVerifyIgnore: []string{"enrollment_code"},
 		},
 	),
+	Entry("assert optional fields are optional",
+		resource.TestStep{
+			ConfigFile: config.StaticFile("testdata/host.tf"),
+			ConfigVariables: config.Variables{
+				"name":       config.StringVariable("host.defined.test"),
+				"network_id": config.StringVariable("network-id"),
+				"role_id":    nil,
+				"tags":       nil,
+			},
+		},
+	),
 )

--- a/internal/resource/host/state.go
+++ b/internal/resource/host/state.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/samber/lo"
 	"github.com/sendsmaily/terraform-provider-definednet/internal/definednet"
 )
 
@@ -33,8 +34,14 @@ func (s *State) ApplyHost(ctx context.Context, host *definednet.Host) (diags dia
 	s.IPAddress = types.StringValue(host.IPAddress)
 	s.Name = types.StringValue(host.Name)
 	s.NetworkID = types.StringValue(host.NetworkID)
-	s.RoleID = types.StringValue(host.RoleID)
-	s.Tags, diags = types.ListValueFrom(ctx, types.StringType, host.Tags)
+
+	if !lo.IsEmpty(host.RoleID) {
+		s.RoleID = types.StringValue(host.RoleID)
+	}
+
+	if len(host.Tags) > 0 {
+		s.Tags, diags = types.ListValueFrom(ctx, types.StringType, host.Tags)
+	}
 
 	return diags
 }

--- a/internal/resource/lighthouse/resource_test.go
+++ b/internal/resource/lighthouse/resource_test.go
@@ -213,4 +213,20 @@ var _ = DescribeTable("lighthouse resource management",
 			ImportStateVerifyIgnore: []string{"enrollment_code"},
 		},
 	),
+	Entry("assert optional fields are optional",
+		resource.TestStep{
+			ConfigFile: config.StaticFile("testdata/lighthouse.tf"),
+			ConfigVariables: config.Variables{
+				"name":        config.StringVariable("lighthouse.defined.test"),
+				"network_id":  config.StringVariable("network-id"),
+				"listen_port": config.IntegerVariable(8484),
+				"static_addresses": config.ListVariable(
+					config.StringVariable("127.0.0.1"),
+					config.StringVariable("172.16.0.1"),
+				),
+				"role_id": nil,
+				"tags":    nil,
+			},
+		},
+	),
 )

--- a/internal/resource/lighthouse/state.go
+++ b/internal/resource/lighthouse/state.go
@@ -53,17 +53,22 @@ func (s *State) ApplyHost(ctx context.Context, lighthouse *definednet.Host) (dia
 
 	diags.Append(d...)
 
-	tags, d := types.ListValueFrom(ctx, types.StringType, lighthouse.Tags)
-	diags.Append(d...)
-
 	s.ID = types.StringValue(lighthouse.ID)
 	s.NetworkID = types.StringValue(lighthouse.NetworkID)
-	s.RoleID = types.StringValue(lighthouse.RoleID)
 	s.StaticAddresses = staticAddrs
 	s.ListenPort = types.Int32Value(int32(lighthouse.ListenPort))
 	s.Name = types.StringValue(lighthouse.Name)
 	s.IPAddress = types.StringValue(lighthouse.IPAddress)
-	s.Tags = tags
+
+	if !lo.IsEmpty(lighthouse.RoleID) {
+		s.RoleID = types.StringValue(lighthouse.RoleID)
+	}
+
+	if len(lighthouse.Tags) > 0 {
+		tags, d := types.ListValueFrom(ctx, types.StringType, lighthouse.Tags)
+		s.Tags = tags
+		diags.Append(d...)
+	}
 
 	return diags
 }


### PR DESCRIPTION
The Defined.net HTTP API client populates optional fields with zero values when executing queries. These values end up in the Terraform state which results in Terraform bailing out with an unexpected new value error.

Fixes https://github.com/sendsmaily/terraform-provider-definednet/issues/48.