### PR TITLE
internal/definednet: Implement configuration overrides capability on the Defined.net HTTP API client

### DIFF
--- a/.cspell/workspace.txt
+++ b/.cspell/workspace.txt
@@ -1,2 +1,15 @@
 # Custom Dictionary Words
 definednet
+dnclient
+ghttp
+gomega
+gstruct
+knownvalue
+onsi
+plancheck
+providerserver
+samber
+sendsmaily
+statecheck
+tfjsonpath
+tfprotov

--- a/internal/definednet/enrollment.go
+++ b/internal/definednet/enrollment.go
@@ -31,12 +31,13 @@ func CreateEnrollment(ctx context.Context, client Client, req CreateEnrollmentRe
 
 // CreateEnrollmentRequest is a request data model for CreateEnrollment endpoint.
 type CreateEnrollmentRequest struct {
-	NetworkID       string   `json:"networkID"`
-	RoleID          string   `json:"roleID"`
-	Name            string   `json:"name"`
-	StaticAddresses []string `json:"staticAddresses"`
-	ListenPort      int      `json:"listenPort"`
-	IsLighthouse    bool     `json:"isLighthouse"`
-	IsRelay         bool     `json:"isRelay"`
-	Tags            []string `json:"tags"`
+	NetworkID       string           `json:"networkID"`
+	RoleID          string           `json:"roleID"`
+	Name            string           `json:"name"`
+	StaticAddresses []string         `json:"staticAddresses"`
+	ListenPort      int              `json:"listenPort"`
+	IsLighthouse    bool             `json:"isLighthouse"`
+	IsRelay         bool             `json:"isRelay"`
+	Tags            []string         `json:"tags"`
+	ConfigOverrides []ConfigOverride `json:"configOverrides"`
 }

--- a/internal/definednet/enrollment_test.go
+++ b/internal/definednet/enrollment_test.go
@@ -23,6 +23,9 @@ var _ = Describe("creating host enrollments", func() {
 				"isLighthouse":    true,
 				"isRelay":         true,
 				"tags":            []string{"tag:one", "tag:two"},
+				"configOverrides": []map[string]string{
+					{"key": "config.override", "value": "value"},
+				},
 			}),
 			ghttp.RespondWithJSONEncoded(http.StatusOK, map[string]any{}),
 		))
@@ -36,6 +39,9 @@ var _ = Describe("creating host enrollments", func() {
 			IsLighthouse:    true,
 			IsRelay:         true,
 			Tags:            []string{"tag:one", "tag:two"},
+			ConfigOverrides: []definednet.ConfigOverride{
+				{Key: "config.override", Value: "value"},
+			},
 		})).Error().NotTo(HaveOccurred())
 
 		Expect(server.ReceivedRequests()).NotTo(BeEmpty(), "assert sanity")
@@ -57,6 +63,12 @@ var _ = Describe("creating host enrollments", func() {
 					"IsLighthouse":    BeTrue(),
 					"IsRelay":         BeTrue(),
 					"Tags":            HaveExactElements("tag:one", "tag:two"),
+					"ConfigOverrides": HaveExactElements(
+						MatchAllFields(Fields{
+							"Key":   Equal("config.override"),
+							"Value": Equal("value"),
+						}),
+					),
 				}),
 				"EnrollmentCode": MatchAllFields(Fields{
 					"Code":            Equal("supersecret"),
@@ -95,7 +107,10 @@ var enrollmentJSONResponse = `{
         "platform": "dnclient",
         "updateAvailable": false,
         "version": "0.1.9"
-      }
+      },
+	  "configOverrides": [
+	    {"key": "config.override", "value": "value"}
+	  ]
     },
     "enrollmentCode": {
       "code": "supersecret",

--- a/internal/definednet/host.go
+++ b/internal/definednet/host.go
@@ -7,16 +7,17 @@ import (
 
 // Host is a data model for Defined.net host.
 type Host struct {
-	ID              string   `json:"id"`
-	NetworkID       string   `json:"networkID"`
-	RoleID          string   `json:"roleID"`
-	Name            string   `json:"name"`
-	IPAddress       string   `json:"ipAddress"`
-	StaticAddresses []string `json:"staticAddresses"`
-	ListenPort      int      `json:"listenPort"`
-	IsLighthouse    bool     `json:"isLighthouse"`
-	IsRelay         bool     `json:"isRelay"`
-	Tags            []string `json:"tags"`
+	ID              string           `json:"id"`
+	NetworkID       string           `json:"networkID"`
+	RoleID          string           `json:"roleID"`
+	Name            string           `json:"name"`
+	IPAddress       string           `json:"ipAddress"`
+	StaticAddresses []string         `json:"staticAddresses"`
+	ListenPort      int              `json:"listenPort"`
+	IsLighthouse    bool             `json:"isLighthouse"`
+	IsRelay         bool             `json:"isRelay"`
+	Tags            []string         `json:"tags"`
+	ConfigOverrides []ConfigOverride `json:"configOverrides"`
 }
 
 // DeleteHost deletes a Defined.net host.
@@ -56,10 +57,11 @@ func UpdateHost(ctx context.Context, client Client, req UpdateHostRequest) (*Hos
 
 // UpdateHostRequest is a request data model for UpdateHost endpoint.
 type UpdateHostRequest struct {
-	ID              string   `json:"-"`
-	RoleID          string   `json:"roleID"`
-	Name            string   `json:"name"`
-	StaticAddresses []string `json:"staticAddresses"`
-	ListenPort      int      `json:"listenPort"`
-	Tags            []string `json:"tags"`
+	ID              string           `json:"-"`
+	RoleID          string           `json:"roleID"`
+	Name            string           `json:"name"`
+	StaticAddresses []string         `json:"staticAddresses"`
+	ListenPort      int              `json:"listenPort"`
+	Tags            []string         `json:"tags"`
+	ConfigOverrides []ConfigOverride `json:"configOverrides"`
 }

--- a/internal/definednet/host_test.go
+++ b/internal/definednet/host_test.go
@@ -40,6 +40,12 @@ var _ = Describe("getting hosts", func() {
 			"IsLighthouse":    BeTrue(),
 			"IsRelay":         BeTrue(),
 			"Tags":            HaveExactElements("tag:one", "tag:two"),
+			"ConfigOverrides": HaveExactElements(
+				MatchAllFields(Fields{
+					"Key":   Equal("config.override"),
+					"Value": Equal("value"),
+				}),
+			),
 		})))
 		Expect(server.ReceivedRequests()).NotTo(BeEmpty(), "assert sanity")
 	})
@@ -55,6 +61,12 @@ var _ = Describe("updating hosts", func() {
 				"staticAddresses": []string{"127.0.0.1:8484", "172.16.0.1:8484"},
 				"listenPort":      8484,
 				"tags":            []string{"tag:one", "tag:two"},
+				"configOverrides": []map[string]string{
+					{
+						"key":   "config.override",
+						"value": "value",
+					},
+				},
 			}),
 			ghttp.RespondWithJSONEncoded(http.StatusOK, map[string]any{}),
 		))
@@ -66,6 +78,9 @@ var _ = Describe("updating hosts", func() {
 			StaticAddresses: []string{"127.0.0.1:8484", "172.16.0.1:8484"},
 			ListenPort:      8484,
 			Tags:            []string{"tag:one", "tag:two"},
+			ConfigOverrides: []definednet.ConfigOverride{
+				{Key: "config.override", Value: "value"},
+			},
 		})).Error().NotTo(HaveOccurred())
 		Expect(server.ReceivedRequests()).NotTo(BeEmpty(), "assert sanity")
 	})
@@ -85,6 +100,12 @@ var _ = Describe("updating hosts", func() {
 				"IsLighthouse":    BeTrue(),
 				"IsRelay":         BeTrue(),
 				"Tags":            HaveExactElements("tag:one", "tag:two"),
+				"ConfigOverrides": HaveExactElements(
+					MatchAllFields(Fields{
+						"Key":   Equal("config.override"),
+						"Value": Equal("value"),
+					}),
+				),
 			})))
 
 		Expect(server.ReceivedRequests()).NotTo(BeEmpty(), "assert sanity")
@@ -117,7 +138,10 @@ var hostJSONResponse = `{
       "platform": "dnclient",
       "updateAvailable": false,
       "version": "0.1.9"
-    }
+    },
+	"configOverrides": [
+	  {"key": "config.override", "value": "value"}
+	]
   },
   "metadata": {}
 }`

--- a/internal/definednet/types.go
+++ b/internal/definednet/types.go
@@ -1,0 +1,7 @@
+package definednet
+
+// ConfigOverride is a data model for Defined.net host configuration override.
+type ConfigOverride struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}

--- a/internal/testing/server/enrollment.go
+++ b/internal/testing/server/enrollment.go
@@ -28,6 +28,7 @@ func (s *Server) createEnrollment(w http.ResponseWriter, r *http.Request) {
 			IsLighthouse:    req.IsLighthouse,
 			IsRelay:         req.IsRelay,
 			Tags:            req.Tags,
+			ConfigOverrides: req.ConfigOverrides,
 		},
 	}
 

--- a/internal/testing/server/host.go
+++ b/internal/testing/server/host.go
@@ -49,6 +49,7 @@ func (s *Server) updateHost(w http.ResponseWriter, r *http.Request) {
 	state.Host.StaticAddresses = req.StaticAddresses
 	state.Host.ListenPort = req.ListenPort
 	state.Host.Tags = req.Tags
+	state.Host.ConfigOverrides = req.ConfigOverrides
 
 	if err := s.Hosts.Replace(*state); err != nil {
 		panic(err)


### PR DESCRIPTION
Consult the HTTP API documentation for specifics: https://docs.defined.net/api/defined-networking-api/