### PR TITLE
internal/resource: Use the Plan to create `host` and `lighthouse` resources

### DIFF
--- a/internal/resource/host/resource.go
+++ b/internal/resource/host/resource.go
@@ -53,7 +53,7 @@ func (r *Resource) Schema(_ context.Context, _ resource.SchemaRequest, resp *res
 func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var state State
 
-	resp.Diagnostics.Append(req.Config.Get(ctx, &state)...)
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/internal/resource/lighthouse/resource.go
+++ b/internal/resource/lighthouse/resource.go
@@ -54,7 +54,7 @@ func (r *Resource) Schema(_ context.Context, _ resource.SchemaRequest, resp *res
 func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var state State
 
-	resp.Diagnostics.Append(req.Config.Get(ctx, &state)...)
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}


### PR DESCRIPTION
The provider is incorrectly using user-passed configuration to create resources when it should be using the planned state.