### PR TITLE
tooling: Update the tested Terraform versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,9 +64,8 @@ jobs:
       fail-fast: false
       matrix:
         terraform:
-          - "1.8.*"
-          - "1.9.*"
-          - "1.10.*"
+          - "1.11.*"
+          - "1.12.*"
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0


### PR DESCRIPTION
Bump the tested versions to `1.11` and `1.12`.