### PR TITLE
internal: Register the role repository on the testing server

### DIFF
--- a/internal/testing/server/server.go
+++ b/internal/testing/server/server.go
@@ -23,6 +23,7 @@ func New() *Server {
 
 	srv := &Server{
 		Hosts: NewRepository[Host](),
+		Roles: NewRepository[Role](),
 	}
 
 	// Hosts.


### PR DESCRIPTION
Enable acceptance testing of Defined.net roles.