### PR TITLE
internal/validation: Implement port range validation helper

### DIFF
--- a/.cspell/workspace.txt
+++ b/.cspell/workspace.txt
@@ -1,4 +1,5 @@
 # Custom Dictionary Words
+basetypes
 boolplanmodifier
 definednet
 dnclient
@@ -7,6 +8,7 @@ gomega
 gstruct
 knownvalue
 listvalidator
+objectvalidator
 onsi
 plancheck
 planmodifier
@@ -21,3 +23,4 @@ tfjsonpath
 tflog
 tfprotov
 tfsdk
+validatordiag

--- a/internal/validation/portrange.go
+++ b/internal/validation/portrange.go
@@ -1,0 +1,85 @@
+package validation
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/helpers/validatordiag"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// PortRange is a port range validator.
+func PortRange(start, end int32) validator.Object {
+	return portRangeValidator{
+		start: start,
+		end:   end,
+	}
+}
+
+type portRangeValidator struct {
+	start, end int32
+}
+
+func (v portRangeValidator) Description(context.Context) string {
+	return fmt.Sprintf("port value must be between %d and %d", v.start, v.end)
+}
+
+func (v portRangeValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+func (v portRangeValidator) ValidateObject(ctx context.Context, req validator.ObjectRequest, resp *validator.ObjectResponse) {
+	val, d := req.ConfigValue.ToObjectValue(ctx)
+	resp.Diagnostics.Append(d...)
+
+	if resp.Diagnostics.HasError() || val.IsNull() || val.IsUnknown() {
+		return
+	}
+
+	attrs := val.Attributes()
+	from, ok := attrs["from"].(types.Int32)
+	if !ok {
+		resp.Diagnostics.Append(validatordiag.InvalidAttributeTypeDiagnostic(
+			req.Path.AtName("from"),
+			"must be int32",
+			attrs["from"].Type(ctx).String(),
+		))
+	}
+
+	to, ok := attrs["to"].(types.Int32)
+	if !ok {
+		resp.Diagnostics.Append(validatordiag.InvalidAttributeTypeDiagnostic(
+			req.Path.AtName("to"),
+			"must be int32",
+			attrs["to"].Type(ctx).String(),
+		))
+	}
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if from.ValueInt32() < v.start || from.ValueInt32() > v.end {
+		resp.Diagnostics.Append(validatordiag.InvalidAttributeValueDiagnostic(
+			req.Path.AtName("from"),
+			v.Description(ctx),
+			from.String(),
+		))
+	}
+
+	if to.ValueInt32() < v.start || to.ValueInt32() > v.end {
+		resp.Diagnostics.Append(validatordiag.InvalidAttributeValueDiagnostic(
+			req.Path.AtName("to"),
+			v.Description(ctx),
+			to.String(),
+		))
+	}
+
+	if to.ValueInt32() <= from.ValueInt32() {
+		resp.Diagnostics.Append(validatordiag.InvalidAttributeCombinationDiagnostic(
+			req.Path,
+			`"to" port must be greater than "from" port`,
+		))
+	}
+}

--- a/internal/validation/portrange_test.go
+++ b/internal/validation/portrange_test.go
@@ -1,0 +1,106 @@
+package validation_test
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/sendsmaily/terraform-provider-definednet/internal/validation"
+)
+
+var _ = Describe("validating port ranges", func() {
+	Specify("valid values pass validation", func(ctx SpecContext) {
+		res := new(validator.ObjectResponse)
+		validation.PortRange(1, 65535).ValidateObject(ctx, validator.ObjectRequest{
+			Path: path.Empty().AtName("test"),
+			ConfigValue: basetypes.NewObjectValueMust(
+				map[string]attr.Type{
+					"from": types.Int32Type,
+					"to":   types.Int32Type,
+				},
+				map[string]attr.Value{
+					"from": types.Int32Value(1024),
+					"to":   types.Int32Value(2048),
+				},
+			),
+		}, res)
+
+		Expect(res.Diagnostics.HasError()).To(BeFalse(), GetDiagnosticsMessage(res.Diagnostics))
+	})
+
+	DescribeTable("invalid values fail validation",
+		func(ctx SpecContext, from, to int, summary, detail string) {
+			res := new(validator.ObjectResponse)
+			validation.PortRange(2048, 4096).ValidateObject(ctx, validator.ObjectRequest{
+				Path: path.Empty().AtName("test"),
+				ConfigValue: basetypes.NewObjectValueMust(
+					map[string]attr.Type{
+						"from": types.Int32Type,
+						"to":   types.Int32Type,
+					},
+					map[string]attr.Value{
+						"from": types.Int32Value(int32(from)),
+						"to":   types.Int32Value(int32(to)),
+					},
+				),
+			}, res)
+
+			Expect(res.Diagnostics.Errors()).To(ContainElement(SatisfyAll(
+				HaveField("Summary()", summary),
+				HaveField("Detail()", detail),
+			)))
+		},
+		Entry("From port value undercuts the allowed range",
+			1024, 4096,
+			"Invalid Attribute Value",
+			"Attribute test.from port value must be between 2048 and 4096, got: 1024",
+		),
+		Entry("From port value exceeds the allowed range",
+			8192, 16384,
+			"Invalid Attribute Value",
+			"Attribute test.from port value must be between 2048 and 4096, got: 8192",
+		),
+		Entry("To port value undercuts the allowed range",
+			512, 1024,
+			"Invalid Attribute Value",
+			"Attribute test.to port value must be between 2048 and 4096, got: 1024",
+		),
+		Entry("To port value exceeds the allowed range",
+			2048, 8192,
+			"Invalid Attribute Value",
+			"Attribute test.to port value must be between 2048 and 4096, got: 8192",
+		),
+		Entry("To port value is greater than from port value",
+			4096, 2048,
+			"Invalid Attribute Combination",
+			`"to" port must be greater than "from" port`,
+		),
+	)
+})
+
+var _ = Describe("validating null values", func() {
+	Specify("null values pass validation", func(ctx SpecContext) {
+		res := new(validator.ObjectResponse)
+		validation.PortRange(1024, 2048).ValidateObject(ctx, validator.ObjectRequest{
+			Path:        path.Empty().AtName("test"),
+			ConfigValue: basetypes.NewObjectNull(nil),
+		}, res)
+
+		Expect(res.Diagnostics.HasError()).To(BeFalse(), GetDiagnosticsMessage(res.Diagnostics))
+	})
+})
+
+var _ = Describe("validating unknown values", func() {
+	Specify("unknown values pass validation", func(ctx SpecContext) {
+		res := new(validator.ObjectResponse)
+		validation.PortRange(1024, 2048).ValidateObject(ctx, validator.ObjectRequest{
+			Path:        path.Empty().AtName("test"),
+			ConfigValue: basetypes.NewObjectUnknown(nil),
+		}, res)
+
+		Expect(res.Diagnostics.HasError()).To(BeFalse(), GetDiagnosticsMessage(res.Diagnostics))
+	})
+})


### PR DESCRIPTION
Provide an implementation for validating `{"from": int32, "to": int32}` Terraform objects. The validator is configurable, exposing a mechanism for configuring the valid port ranges.