### PR TITLE
resource: Add support for allow-all firewall rules

### DIFF
--- a/internal/definednet/role.go
+++ b/internal/definednet/role.go
@@ -16,11 +16,11 @@ type (
 
 	// FirewallRule is a data model for Defined.net role's firewall rule.
 	FirewallRule struct {
-		Protocol      string    `json:"protocol"`
-		Description   string    `json:"description"`
-		AllowedRoleID string    `json:"allowedRoleID,omitempty"`
-		AllowedTags   []string  `json:"allowedTags,omitempty"`
-		PortRange     PortRange `json:"portRange"`
+		Protocol      string     `json:"protocol"`
+		Description   string     `json:"description"`
+		AllowedRoleID string     `json:"allowedRoleID,omitempty"`
+		AllowedTags   []string   `json:"allowedTags,omitempty"`
+		PortRange     *PortRange `json:"portRange,omitempty"`
 	}
 
 	// PortRange is a data model for Defined.net role firewall rule's port range.

--- a/internal/definednet/role_test.go
+++ b/internal/definednet/role_test.go
@@ -39,6 +39,13 @@ var _ = Describe("creating roles", func() {
 							"to":   65535,
 						},
 					},
+					{
+						"protocol":    "ANY",
+						"description": "Allow all ports",
+						"allowedTags": []string{
+							"tag:superuser",
+						},
+					},
 				},
 			}),
 			ghttp.RespondWithJSONEncoded(http.StatusOK, map[string]any{}),
@@ -52,7 +59,7 @@ var _ = Describe("creating roles", func() {
 					Protocol:      "TCP",
 					Description:   "Allow SSH access",
 					AllowedRoleID: "allowed-role-id",
-					PortRange: definednet.PortRange{
+					PortRange: &definednet.PortRange{
 						From: 22,
 						To:   22,
 					},
@@ -64,9 +71,16 @@ var _ = Describe("creating roles", func() {
 						"tag:one",
 						"tag:two",
 					},
-					PortRange: definednet.PortRange{
+					PortRange: &definednet.PortRange{
 						From: 32768,
 						To:   65535,
+					},
+				},
+				{
+					Protocol:    "ANY",
+					Description: "Allow all ports",
+					AllowedTags: []string{
+						"tag:superuser",
 					},
 				},
 			},
@@ -104,10 +118,10 @@ var _ = Describe("getting roles", func() {
 						"Description":   Equal("Allow SSH access"),
 						"AllowedRoleID": Equal("allowed-role-id"),
 						"AllowedTags":   BeEmpty(),
-						"PortRange": MatchAllFields(Fields{
+						"PortRange": PointTo(MatchAllFields(Fields{
 							"From": Equal(22),
 							"To":   Equal(22),
-						}),
+						})),
 					}),
 					MatchAllFields(Fields{
 						"Protocol":      Equal("ANY"),
@@ -117,10 +131,19 @@ var _ = Describe("getting roles", func() {
 							"tag:one",
 							"tag:two",
 						),
-						"PortRange": MatchAllFields(Fields{
+						"PortRange": PointTo(MatchAllFields(Fields{
 							"From": Equal(32768),
 							"To":   Equal(65535),
-						}),
+						})),
+					}),
+					MatchAllFields(Fields{
+						"Protocol":      Equal("ANY"),
+						"Description":   Equal("Allow all ports"),
+						"AllowedRoleID": BeEmpty(),
+						"AllowedTags": HaveExactElements(
+							"tag:superuser",
+						),
+						"PortRange": BeNil(),
 					}),
 				),
 			})))
@@ -158,6 +181,13 @@ var _ = Describe("updating roles", func() {
 							"to":   65535,
 						},
 					},
+					{
+						"protocol":    "ANY",
+						"description": "Allow all ports",
+						"allowedTags": []string{
+							"tag:superuser",
+						},
+					},
 				},
 			}),
 			ghttp.RespondWithJSONEncoded(http.StatusOK, map[string]any{}),
@@ -172,7 +202,7 @@ var _ = Describe("updating roles", func() {
 					Protocol:      "TCP",
 					Description:   "Allow SSH access",
 					AllowedRoleID: "allowed-role-id",
-					PortRange: definednet.PortRange{
+					PortRange: &definednet.PortRange{
 						From: 22,
 						To:   22,
 					},
@@ -184,9 +214,16 @@ var _ = Describe("updating roles", func() {
 						"tag:one",
 						"tag:two",
 					},
-					PortRange: definednet.PortRange{
+					PortRange: &definednet.PortRange{
 						From: 32768,
 						To:   65535,
+					},
+				},
+				{
+					Protocol:    "ANY",
+					Description: "Allow all ports",
+					AllowedTags: []string{
+						"tag:superuser",
 					},
 				},
 			},
@@ -208,10 +245,10 @@ var _ = Describe("updating roles", func() {
 						"Description":   Equal("Allow SSH access"),
 						"AllowedRoleID": Equal("allowed-role-id"),
 						"AllowedTags":   BeEmpty(),
-						"PortRange": MatchAllFields(Fields{
+						"PortRange": PointTo(MatchAllFields(Fields{
 							"From": Equal(22),
 							"To":   Equal(22),
-						}),
+						})),
 					}),
 					MatchAllFields(Fields{
 						"Protocol":      Equal("ANY"),
@@ -221,10 +258,19 @@ var _ = Describe("updating roles", func() {
 							"tag:one",
 							"tag:two",
 						),
-						"PortRange": MatchAllFields(Fields{
+						"PortRange": PointTo(MatchAllFields(Fields{
 							"From": Equal(32768),
 							"To":   Equal(65535),
-						}),
+						})),
+					}),
+					MatchAllFields(Fields{
+						"Protocol":      Equal("ANY"),
+						"Description":   Equal("Allow all ports"),
+						"AllowedRoleID": BeEmpty(),
+						"AllowedTags": HaveExactElements(
+							"tag:superuser",
+						),
+						"PortRange": BeNil(),
 					}),
 				),
 			})))
@@ -261,6 +307,13 @@ var roleJSONResponse = `{
           "from": 32768,
           "to": 65535
         }
+      },
+      {
+        "protocol": "ANY",
+        "description": "Allow all ports",
+        "allowedTags": [
+          "tag:superuser"
+        ]
       }
     ]
   },

--- a/internal/resource/role/resource.go
+++ b/internal/resource/role/resource.go
@@ -68,12 +68,12 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 			out.AllowedRoleID = rule.AllowedRoleID.ValueString()
 
 			if lo.IsNotNil(rule.PortRange) {
-				out.PortRange = definednet.PortRange{
+				out.PortRange = &definednet.PortRange{
 					From: int(rule.PortRange.From.ValueInt32()),
 					To:   int(rule.PortRange.To.ValueInt32()),
 				}
-			} else {
-				out.PortRange = definednet.PortRange{
+			} else if !rule.Port.IsNull() {
+				out.PortRange = &definednet.PortRange{
 					From: int(rule.Port.ValueInt32()),
 					To:   int(rule.Port.ValueInt32()),
 				}
@@ -169,12 +169,12 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 			out.AllowedRoleID = rule.AllowedRoleID.ValueString()
 
 			if lo.IsNotNil(rule.PortRange) {
-				out.PortRange = definednet.PortRange{
+				out.PortRange = &definednet.PortRange{
 					From: int(rule.PortRange.From.ValueInt32()),
 					To:   int(rule.PortRange.To.ValueInt32()),
 				}
-			} else {
-				out.PortRange = definednet.PortRange{
+			} else if !rule.Port.IsNull() {
+				out.PortRange = &definednet.PortRange{
 					From: int(rule.Port.ValueInt32()),
 					To:   int(rule.Port.ValueInt32()),
 				}

--- a/internal/resource/role/schema.go
+++ b/internal/resource/role/schema.go
@@ -106,10 +106,6 @@ var Schema = schema.Schema{
 						path.MatchRelative().AtName("allowed_role_id"),
 						path.MatchRelative().AtName("allowed_tags"),
 					),
-					objectvalidator.AtLeastOneOf(
-						path.MatchRelative().AtName("port"),
-						path.MatchRelative().AtName("port_range"),
-					),
 				},
 			},
 		},

--- a/internal/resource/role/testdata/role_any_port.tf
+++ b/internal/resource/role/testdata/role_any_port.tf
@@ -1,0 +1,38 @@
+provider "definednet" {
+  token = "supersecret"
+}
+
+variable "name" {
+  type = string
+}
+
+variable "description" {
+  type = string
+  default = ""
+}
+
+variable "rules" {
+  type = list(object({
+    protocol = string
+    description = string
+    allowed_role_id = string
+    allowed_tags = list(string)
+  }))
+
+  default = []
+}
+
+resource "definednet_role" "test" {
+  name       = var.name
+  description = var.description
+
+  dynamic "rule" {
+    for_each = var.rules
+    content {
+      protocol = rule.value.protocol
+      description = rule.value.description
+      allowed_role_id = rule.value.allowed_role_id
+      allowed_tags = rule.value.allowed_tags
+    }
+  }
+}


### PR DESCRIPTION
Provide a mechanism for configuring allow-all firewall rules by omitting both `port` and `port_range` attributes from the role specification.